### PR TITLE
Feature/anon execute query

### DIFF
--- a/myads_service/config.py
+++ b/myads_service/config.py
@@ -11,6 +11,9 @@ SQLALCHEMY_ECHO = False
 MYADS_SOLR_QUERY_ENDPOINT = 'https://api.adsabs.harvard.edu/v1/search/query'
 MYADS_SOLR_BIGQUERY_ENDPOINT = 'https://api.adsabs.harvard.edu/v1/search/bigquery'
 
+# location of the uid look up
+MYADS_USER_EMAIL_ADSWS_API_URL = 'https://api.adsabs.harvard.edu/v1/user'
+
 # alembic will 
 use_flask_db_url = True
 


### PR DESCRIPTION
Allowing anonymous users to execute certain queries from certain clients (in this case they are set by tugboat), but not another user's. It also ensures only users that created the query, can execute that query. In summary:
- Users can only access queries they've stored
- User uid is stored on store-query
- Anonymous (and logged in) users can access queries stored by harbour@ads
- Tests for the above added, and others modified to pass

If we incorporate this, it would be mean that:
- Users cannot share links with other people as they require user-specific credentials
- Users who bookmarked (before this PR) URLs will no longer work, as the uid wasn't being stored (as far as I can tell) when queries were stored - defaults to 0 (anonymous user)

Advantages of doing it this way:
- We need only give 'execute-query' scope to anonymous users, and not 'store-query'
- We can track when queries are being used for anonymous users (as they are done by harbour@ads)
- We can easily carry out maintenance/clear up of queries that are stale

I'm open to alternatives, this isn't a big deal imo, with the only 'issue' being that someone could try to mass-figure-out what queries you store. Not sure you can make much money from that.
