### PR TITLE
Scope `/notifications` endpoint

### DIFF
--- a/vault_service/views/user.py
+++ b/vault_service/views/user.py
@@ -229,7 +229,7 @@ def myads_notifications(myads_id=None):
     except Exception as e:
         return json.dumps({'msg': e.message or e.description}), 400
 
-    user_id = int(headers['X-api-uid'])
+    user_id = int(headers['X-Api-Uid'])
 
     if user_id == current_app.config['BOOTSTRAP_USER_ID']:
         return json.dumps({'msg': 'Sorry, you can\'t use this service as an anonymous user'}), 400

--- a/vault_service/views/user.py
+++ b/vault_service/views/user.py
@@ -215,7 +215,7 @@ def store_data():
         return json.dumps(response_data), 200
 
 
-@advertise(scopes=[], rate_limit=[1000, 3600*24])
+@advertise(scopes=['store-preferences'], rate_limit=[1000, 3600*24])
 @bp.route('/notifications', methods=['GET', 'POST'])
 @bp.route('/notifications/<myads_id>', methods=['GET', 'PUT', 'DELETE'])
 def myads_notifications(myads_id=None):
@@ -229,7 +229,7 @@ def myads_notifications(myads_id=None):
     except Exception as e:
         return json.dumps({'msg': e.message or e.description}), 400
 
-    user_id = int(headers['X-Api-Uid'])
+    user_id = int(headers['X-api-uid'])
 
     if user_id == current_app.config['BOOTSTRAP_USER_ID']:
         return json.dumps({'msg': 'Sorry, you can\'t use this service as an anonymous user'}), 400


### PR DESCRIPTION
Add `store-preferences` scope to `/notifications` endpoint as an additional guard against anonymous user erroneously creating notifications.